### PR TITLE
Preserve request path when proxying

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -313,8 +313,8 @@ def auth_for_nginx(request: Request):
         redir = f"/_challenge?host={host}&next={next_path}"
         return Response(status_code=401, headers={"X-Redirect": redir})
 
-    # 認可OK → Nginx に上流URLを渡す
-    return Response(status_code=204, headers={"X-Upstream": upstream})
+    # 認可OK → Nginx に上流URLを渡す（末尾のスラッシュを除去）
+    return Response(status_code=204, headers={"X-Upstream": upstream.rstrip("/")})
 
 
 # -------------------------

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -82,9 +82,9 @@ http {
       # バッファ系は好みで
       proxy_buffering on;
 
-      # upstream は /_auth が返した URL
-      proxy_pass $upstream_url;
-    }
+        # upstream は /_auth が返した URL。元のリクエストURIを付与
+        proxy_pass $upstream_url$request_uri;
+      }
 
     location @challenge_redirect {
       return 302 $redirect_url;


### PR DESCRIPTION
## Summary
- Ensure upstream URL from auth drops trailing slash
- Forward original request URI when proxying

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68affc685f88832bb0ab26874712e798